### PR TITLE
SvelteKit: Fix supabaseServerClient with request and withApiAuth return type

### DIFF
--- a/packages/sveltekit/src/utils/supabaseServerClient.ts
+++ b/packages/sveltekit/src/utils/supabaseServerClient.ts
@@ -1,6 +1,10 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { skHelper } from '../instance';
-import { type CookieOptions, COOKIE_OPTIONS } from '@supabase/auth-helpers-shared';
+import {
+  type CookieOptions,
+  COOKIE_OPTIONS,
+  parseCookie
+} from '@supabase/auth-helpers-shared';
 
 /**
  * This is a helper method to wrap your SupabaseClient to inject a user's access_token to make use of RLS on the server side.
@@ -47,7 +51,9 @@ function supabaseServerClient(
   const { supabaseClient } = skHelper();
   const access_token =
     typeof requestOrAccessToken !== 'string'
-      ? requestOrAccessToken?.headers.get(`${cookieOptions.name}-access-token`)
+      ? parseCookie(requestOrAccessToken?.headers.get('cookie'))?.[
+          `${cookieOptions.name}-access-token`
+        ]
       : requestOrAccessToken;
   if (access_token !== null) {
     supabaseClient?.auth.setAuth(access_token);

--- a/packages/sveltekit/src/utils/withApiAuth.ts
+++ b/packages/sveltekit/src/utils/withApiAuth.ts
@@ -1,4 +1,5 @@
 import type { User } from '@supabase/supabase-js';
+
 import { isFunction } from './guards';
 
 interface ApiAuthOpts {
@@ -7,9 +8,9 @@ interface ApiAuthOpts {
   user: User;
 }
 
-export default async function withApiAuth(
+export default async function withApiAuth<T>(
   { redirectTo = '/', user, status = 303 }: ApiAuthOpts,
-  fn: () => {}
+  fn: () => T
 ) {
   if (!user) {
     return {


### PR DESCRIPTION
When a request is passed in to `supabaseServerClient` it was looking at the header for the access token. This pulls the access token off of the cookie header.

When using `withApiAuth`, the returned type was hardcoded to `{}`. This allows the proper types to be inferred from the function so they may be used downstream. See this [TS Playground](https://www.typescriptlang.org/play?#code/GYVwdgxgLglg9mABAWxgZzTMBzAKgTwAcBTACmDAC5FSBKAXgD5EBvAX1pYChFfEAnYlBD8kFOgG4ubLl1CRYCRFmDF+ggCYESAHlyNyVGg2a5OPPoOGjE42lJlzw0eEijE0UOqwu8rIpBZgODhqAHIARgAmAGYwgBpEACMAQ35wgBYAVgA2MJlHCARPAQ9CYuJEehR0TBxtMndPWlkisBLBNHL24iiq5TBVdWItIkaPKFogA) for an example.