### PR TITLE
Fixes link to Sveltekit .env.example file

### DIFF
--- a/packages/sveltekit/README.md
+++ b/packages/sveltekit/README.md
@@ -29,7 +29,7 @@ This library supports the following tooling versions:
 
 ### Configuration
 
-Set up the fillowing env vars. For local development you can set them in a `.env` file. See an example [here](../../examples/sveltekit/example.env)).
+Set up the fillowing env vars. For local development you can set them in a `.env` file. See an example [here](../../examples/sveltekit/.env.example).
 
 ```bash
 # Find these in your Supabase project settings > API


### PR DESCRIPTION
Fixes link to example .env file in Sveltekit README

Fixes #210